### PR TITLE
test: remove appearances of reserved domain example.org

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_cli_createuser(cli_app):
     # Create user
     result = runner.invoke(
         users_create,
-        ['email@example.org', '--password', '123456']
+        ['email@test.org', '--password', '123456']
     )
     assert result.exit_code == 0
 
@@ -57,7 +57,7 @@ def test_cli_addremove_role(cli_app):
     # Create a user and a role
     result = runner.invoke(
         users_create,
-        ['a@example.org', '--password', '123456']
+        ['a@test.org', '--password', '123456']
     )
     assert result.exit_code == 0
     result = runner.invoke(roles_create, ['superuser'])
@@ -65,43 +65,43 @@ def test_cli_addremove_role(cli_app):
 
     # User not found
     result = runner.invoke(
-        roles_add, ['inval@example.org', 'superuser'])
+        roles_add, ['inval@test.org', 'superuser'])
     assert result.exit_code != 0
 
     # Add:
     result = runner.invoke(
-        roles_add, ['a@example.org', 'invalid'])
+        roles_add, ['a@test.org', 'invalid'])
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['inval@example.org', 'superuser'])
+        roles_remove, ['inval@test.org', 'superuser'])
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        roles_remove, ['a@example.org', 'invalid'])
+        roles_remove, ['a@test.org', 'invalid'])
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['b@example.org', 'superuser'])
+        roles_remove, ['b@test.org', 'superuser'])
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['a@example.org', 'superuser'])
+        roles_remove, ['a@test.org', 'superuser'])
     assert result.exit_code != 0
 
     # Add:
     result = runner.invoke(roles_add,
-                           ['a@example.org', 'superuser'])
+                           ['a@test.org', 'superuser'])
     assert result.exit_code == 0
     result = runner.invoke(
         roles_add,
-        ['a@example.org', 'superuser'])
+        ['a@test.org', 'superuser'])
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        roles_remove, ['a@example.org', 'superuser'])
+        roles_remove, ['a@test.org', 'superuser'])
     assert result.exit_code == 0
 
 
@@ -112,7 +112,7 @@ def test_cli_activate_deactivate(cli_app):
     # Create a user
     result = runner.invoke(
         users_create,
-        ['a@example.org', '--password', '123456']
+        ['a@test.org', '--password', '123456']
     )
     assert result.exit_code == 0
 
@@ -122,15 +122,15 @@ def test_cli_activate_deactivate(cli_app):
     result = runner.invoke(users_deactivate, ['in@valid.org'])
     assert result.exit_code != 0
 
-    result = runner.invoke(users_activate, ['a@example.org'])
+    result = runner.invoke(users_activate, ['a@test.org'])
     assert result.exit_code == 0
-    result = runner.invoke(users_activate, ['a@example.org'])
+    result = runner.invoke(users_activate, ['a@test.org'])
     assert result.exit_code == 0
 
     # Deactivate
     result = runner.invoke(users_deactivate,
-                           ['a@example.org'])
+                           ['a@test.org'])
     assert result.exit_code == 0
     result = runner.invoke(users_deactivate,
-                           ['a@example.org'])
+                           ['a@test.org'])
     assert result.exit_code == 0


### PR DESCRIPTION
The recent release of `email-validator` (v1.2.0) forbids the usage of [special domain names](https://github.com/JoshData/python-email-validator/blob/8f4cf0040113e7422ac8d1e509b264fc5a2404b5/email_validator/__init__.py#L45)